### PR TITLE
Added python 2.6 unit test support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: python
 python:
+  - "2.6"
   - "2.7"
   - "3.2"
   - "3.3"

--- a/runtests.py
+++ b/runtests.py
@@ -8,12 +8,10 @@ from credstash import paddedInt
 class TestKeyValuePairExtraction(unittest.TestCase):
 
     def test_key_value_pair_has_two_equals(self):
-        with self.assertRaises(argparse.ArgumentTypeError):
-            key_value_pair("==")
+        self.assertRaises(argparse.ArgumentTypeError, key_value_pair , "==")
 
     def test_key_value_pair_has_zero_equals(self):
-        with self.assertRaises(argparse.ArgumentTypeError):
-            key_value_pair("")
+        self.assertRaises(argparse.ArgumentTypeError, key_value_pair, "")
 
     def test_key_value_pair_has_one_equals(self):
         self.assertEqual(key_value_pair("="), ["",""])
@@ -23,6 +21,7 @@ class TestKeyValuePairExtraction(unittest.TestCase):
 
     def test_key_value_pair_has_one_equals_with_values(self):
         self.assertEqual(key_value_pair("key1=value1"), ["key1","value1"])
+
 
 class TestExpandingWildcard(unittest.TestCase):
     secrets_set = ["a", "b", "ab", " a", " b", "ba", "abc", "a[anyvalue]z", "a b", "aabb"]
@@ -49,6 +48,7 @@ class TestExpandingWildcard(unittest.TestCase):
     def test_three_wild_card_with_many_matches(self):
         self.assertEqual(expand_wildcard("Q*E*Q*E", self.secrets_set2), ["QrEQrE", "QErQE"])
 
+
 class TestPadLeft(unittest.TestCase):
     def test_zero(self):
         i = 0
@@ -65,6 +65,7 @@ class TestPadLeft(unittest.TestCase):
     def test_huge_number(self):
         i = 12345678901234567890123
         self.assertEqual(paddedInt(i), str(i).zfill(19))
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Python 2.6 is back in the travis.yml and the structure of the assertions for catching errors has been changed to be compatible with python 2.6. 
